### PR TITLE
clarification : adding function name to parameter value

### DIFF
--- a/lib/challenge/challenge.go
+++ b/lib/challenge/challenge.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -26,8 +27,13 @@ func Format(a ...interface{}) string {
 			// byte, rune : a single-quoted character literal safely escaped with Go syntax
 			ss[i] = fmt.Sprintf("%q", v)
 		default:
-			// a Go-syntax representation of the value
-			ss[i] = fmt.Sprintf("%#v", v)
+			if function := fmt.Sprint(reflect.TypeOf(v)); strings.Contains(function, "func") {
+				// function: function passed as parameter should output the name of the function
+				ss[i] = runtime.FuncForPC(reflect.ValueOf(v).Pointer()).Name()
+			} else {
+				// a Go-syntax representation of the value
+				ss[i] = fmt.Sprintf("%#v", v)
+			}
 		}
 	}
 	return strings.Join(ss, ", ")

--- a/lib/challenge/challenge.go
+++ b/lib/challenge/challenge.go
@@ -27,8 +27,8 @@ func Format(a ...interface{}) string {
 			// byte, rune : a single-quoted character literal safely escaped with Go syntax
 			ss[i] = fmt.Sprintf("%q", v)
 		default:
-			if function := fmt.Sprint(reflect.TypeOf(v)); strings.Contains(function, "func") {
-				// function: function passed as parameter should output the name of the function
+			if reflect.TypeOf(v).Kind() == reflect.Func {
+				// Function passed as parameter should output the name of the function
 				ss[i] = runtime.FuncForPC(reflect.ValueOf(v).Pointer()).Name()
 			} else {
 				// a Go-syntax representation of the value

--- a/tests/advancedsortwordarr_test/main.go
+++ b/tests/advancedsortwordarr_test/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -36,9 +37,10 @@ func main() {
 		student.AdvancedSortWordArr(cp_stu, strings.Compare)
 
 		if !reflect.DeepEqual(cp_stu, cp_sol) {
-			challenge.Fatalf("%s(%v) == %v instead of %v\n",
+			challenge.Fatalf("%s(%v, %s) == %v instead of %v\n",
 				"AdvancedSortWordArr",
 				arg,
+				runtime.FuncForPC(reflect.ValueOf(strings.Compare).Pointer()).Name(),
 				cp_stu,
 				cp_sol,
 			)


### PR DESCRIPTION
`challenge.go`: added function name to parameter value for clarification reason.

in case of error the output passed form this : 

```console
Map((func(int) bool)(0x4b72c0), []int{-967443, 619198, 463968, 143759, -982455, -583859, -661349, 610921}) == []bool{false, true, true, true, true, true, true, true} instead of []bool{false, true, true, true, false, false, false, true}
exit status 1
```

to

```console
Map(github.com/01-edu/go-tests/lib/is.Prime, []int{-944272, -826596, -612484, -646566, 771985, -978566, 761982, -398507}) == []bool{false, false, true, true, false, true, false, true} instead of []bool{false, false, false, false, false, false, false, false}
exit status 1
```

`advancedsortwordarr_test/main.go`: added function name for clarification reason.