### PR TITLE
Feature/improve tests

### DIFF
--- a/lib/challenge/challenge.go
+++ b/lib/challenge/challenge.go
@@ -77,11 +77,11 @@ func Monitor(fn interface{}, args []interface{}) (out Output) {
 	outC := make(chan string)
 	var buf strings.Builder
 	go func() {
-		io.Copy(&buf, r)
+		_, _ = io.Copy(&buf, r)
 		outC <- buf.String()
 	}()
 	os.Stdout = old
-	w.Close()
+	_ = w.Close()
 	out.Stdout = <-outC
 	return out
 }
@@ -108,17 +108,17 @@ func Function(name string, actualFunction, expectedFunction interface{}, args ..
 }
 
 func Fatal(a ...interface{}) {
-	fmt.Fprint(os.Stderr, a...)
+	_, _ = fmt.Fprint(os.Stderr, a...)
 	os.Exit(1)
 }
 
 func Fatalln(a ...interface{}) {
-	fmt.Fprintln(os.Stderr, a...)
+	_, _ = fmt.Fprintln(os.Stderr, a...)
 	os.Exit(1)
 }
 
 func Fatalf(format string, a ...interface{}) {
-	fmt.Fprintf(os.Stderr, format, a...)
+	_, _ = fmt.Fprintf(os.Stderr, format, a...)
 	os.Exit(1)
 }
 

--- a/lib/challenge/challenge.go
+++ b/lib/challenge/challenge.go
@@ -86,23 +86,23 @@ func Monitor(fn interface{}, args []interface{}) (out Output) {
 	return out
 }
 
-func Function(name string, fn1, fn2 interface{}, args ...interface{}) {
-	st1 := Monitor(fn1, args)
-	st2 := Monitor(fn2, args)
-	if !reflect.DeepEqual(st1.Results, st2.Results) {
+func Function(name string, actualFunction, expectedFunction interface{}, args ...interface{}) {
+	actualFunctionCall := Monitor(actualFunction, args)
+	expectedFunctionCall := Monitor(expectedFunction, args)
+	if !reflect.DeepEqual(actualFunctionCall.Results, expectedFunctionCall.Results) {
 		Fatalf("%s(%s) == %s instead of %s\n",
 			name,
 			Format(args...),
-			Format(st1.Results...),
-			Format(st2.Results...),
+			Format(actualFunctionCall.Results...),
+			Format(expectedFunctionCall.Results...),
 		)
 	}
-	if !reflect.DeepEqual(st1.Stdout, st2.Stdout) {
+	if !reflect.DeepEqual(actualFunctionCall.Stdout, expectedFunctionCall.Stdout) {
 		Fatalf("%s(%s) prints:\n%s\ninstead of:\n%s\n",
 			name,
 			Format(args...),
-			Format(st1.Stdout),
-			Format(st2.Stdout),
+			Format(actualFunctionCall.Stdout),
+			Format(expectedFunctionCall.Stdout),
 		)
 	}
 }

--- a/tests/quad_test/main.go
+++ b/tests/quad_test/main.go
@@ -152,11 +152,11 @@ func main() {
 	// Tests all possibilities including 0 0, -x y, x -y
 	for i := 0; i < len(table); i += 2 {
 		if i != len(table)-1 {
-			challenge.Function("quadA", quadA, student.QuadA, table[i], table[i+1])
-			challenge.Function("quadB", quadB, student.QuadB, table[i], table[i+1])
-			challenge.Function("quadC", quadC, student.QuadC, table[i], table[i+1])
-			challenge.Function("quadD", quadD, student.QuadD, table[i], table[i+1])
-			challenge.Function("quadE", quadE, student.QuadE, table[i], table[i+1])
+			challenge.Function("quadA", student.QuadA, quadA, table[i], table[i+1])
+			challenge.Function("quadB", student.QuadB, quadB, table[i], table[i+1])
+			challenge.Function("quadC", student.QuadC, quadC, table[i], table[i+1])
+			challenge.Function("quadD", student.QuadD, quadD, table[i], table[i+1])
+			challenge.Function("quadE", student.QuadE, quadE, table[i], table[i+1])
 		}
 	}
 }


### PR DESCRIPTION
1. the `Function` testing utility makes some hidden assumptions about which input is the expected and which is the function under test. Make this explicit.
2. Explicitly ignore errors in order to appease linters
3. Flip calls to `Function` in `quad_test` to reflect usage.