### PR TITLE
alphamirror: fix newline

### DIFF
--- a/solutions/alphamirror/main.go
+++ b/solutions/alphamirror/main.go
@@ -15,8 +15,6 @@ func main() {
 				arg[i] = 'Z' - ch + 'A'
 			}
 		}
-		fmt.Print(string(arg))
+		fmt.Println(string(arg))
 	}
-
-	fmt.Println()
 }


### PR DESCRIPTION
As per the the current subject https://github.com/01-edu/public/blob/88c3cc52a928a7c66d15a64def24ddedc344168f/subjects/alphamirror/README.md the newline should not be printed in the case the number of arguments is not 1.