### PR TITLE
Reproduce the behavior of tail

### DIFF
--- a/solutions/ztail/main.go
+++ b/solutions/ztail/main.go
@@ -27,6 +27,7 @@ func main() {
 	flag.Int64Var(&bytes, "c", 0, "output the last NUM bytes")
 	flag.Parse()
 	filenames := flag.Args()
+	var oneFileHasBeenPrinted bool
 	for i, filename := range filenames {
 		file, err := os.Open(filename)
 		if notNil(err) {
@@ -47,12 +48,13 @@ func main() {
 			continue
 		}
 		if len(filenames) > 1 {
-			if i > 0 {
+			if i > 0 && oneFileHasBeenPrinted {
 				fmt.Println()
 			}
 			fmt.Println("==>", filename, "<==")
 		}
 		os.Stdout.Write(b)
+		oneFileHasBeenPrinted = true
 	}
 	os.Exit(status)
 }


### PR DESCRIPTION
This modification makes ztail reproduce the behavior of tail in the case there are multiple files to output (a banner is printed).
In particular, the filename banner should not be preceded by a newline if it's preceded only by errors.

The subject is a little ambiguous: `If several files are given, print a newline and the file name between each one of them`. It notably doesn't specify what to put before the first file.
But the natural interpretation of it should be to not to put a newline before the first file that is actually printed.