### PR TITLE
DEV-3505-fix(rockandroll): fix bug

### DIFF
--- a/solutions/rockandroll.go
+++ b/solutions/rockandroll.go
@@ -2,7 +2,7 @@ package solutions
 
 func RockAndRoll(n int) string {
 	if n < 0 {
-		return "error: number is negative"
+		return "error: number is negative\n"
 	}
 
 	if (n%2 == 0) && (n%3 == 0) {
@@ -14,5 +14,5 @@ func RockAndRoll(n int) string {
 	if n%3 == 0 {
 		return "roll\n"
 	}
-	return "error: non divisible"
+	return "error: non divisible\n"
 }


### PR DESCRIPTION
- add missing '\n' after 'error: number is negative'
- add missing '\n' after 'error: non divisible'