### PR TITLE
DEV-5076 Improve `go-tests` CI/CD workflow

### DIFF
--- a/.github/workflows/ga-image-build-branch.yml
+++ b/.github/workflows/ga-image-build-branch.yml
@@ -1,0 +1,33 @@
+name: 🌳 On Branch - Build and Test Docker Image
+
+on:
+  pull_request:
+    branches: ["master"]
+
+jobs:
+  build-image:
+    name: 🏗️ Build Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🐧 Checkout
+        uses: actions/checkout@v3
+
+      - name: 📦 Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🐳 Login to docker.01-edu.org Registry
+        uses: docker/login-action@v2
+        with:
+          registry: docker.01-edu.org
+          username: ${{ secrets.USER_DOCKER_01EDU_ORG }}
+          password: ${{ secrets.SECRET_DOCKER_01EDU_ORG }}
+
+      - name: 🏗️ Build the Go tests Docker image
+        run: |
+          docker build . --file Dockerfile --tag ghcr.io/01-edu/test-go:PR${{ github.event.pull_request.number }}
+          docker push ghcr.io/01-edu/test-go:PR${{ github.event.pull_request.number }}

--- a/.github/workflows/ga-image-build-master.yml
+++ b/.github/workflows/ga-image-build-master.yml
@@ -1,33 +1,33 @@
-name: Docker Image CI
+name: 🐳 On Master - Build and Test Docker Image
 
 on:
   push:
-    branches: ['master']
-  pull_request:
-    branches: ['master']
+    branches: ["master"]
 
 jobs:
-  build:
+  build-image:
+    name: 🏗️ Build Image
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: 🐧 Checkout
+        uses: actions/checkout@v3
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.1.0
+      - name: 📦 Login to GitHub Container Registry
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Login to docker.01-edu.org Registry
-        uses: docker/login-action@v1
+
+      - name: 🐳 Login to docker.01-edu.org Registry
+        uses: docker/login-action@v2
         with:
           registry: docker.01-edu.org
           username: ${{ secrets.USER_DOCKER_01EDU_ORG }}
           password: ${{ secrets.SECRET_DOCKER_01EDU_ORG }}
 
-      - name: Build the Go tests Docker image
+      - name: 🏗️ Build the Go tests Docker image
         run: |
           docker build . --file Dockerfile --tag ghcr.io/01-edu/test-go:latest
           docker push ghcr.io/01-edu/test-go:latest

--- a/.github/workflows/ga-image-sanitize.yml
+++ b/.github/workflows/ga-image-sanitize.yml
@@ -1,0 +1,39 @@
+name: 🧼 Sanitize – Generated Docker Images
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      keep-last:
+        description: >
+          Delete all untagged images except the last N
+        required: false
+        default: "1"
+
+jobs:
+  delete-pr-tagged-image:
+    name: 🗑️ Delete PR${{github.event.pull_request.number}} Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🗑️ Delete image PR${{github.event.pull_request.number}}
+        uses: bots-house/ghcr-delete-image-action@v1.1.0
+        with:
+          owner: 01-edu
+          name: test-go
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: PR${{github.event.pull_request.number}}
+        continue-on-error: true
+          
+  delete-untagged-images:
+    name: 🔥 Clear Untagged Images
+    needs: delete-pr-tagged-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🔥 Clear all untagged images
+        uses: bots-house/ghcr-delete-image-action@v1.1.0
+        with:
+          owner: 01-edu
+          name: test-go
+          token: ${{ secrets.GITHUB_TOKEN }}
+          untagged-keep-latest: ${{ github.event.inputs.keep-last }}


### PR DESCRIPTION
### Why?

Currently, CI/CD actions are working on both PRs and Master branch at the same time, so if a PR fails, the master is “broken” 

### Solution Overview

Separate CI/CD actions to distinguish the differences. 

### Implementation Details

3 Different CI/CD actions:

- ga-image-sanitize
- ga-image-build-master
- ga-image-sanitize