### PR TITLE
CON-1672-add-scirpt-to-test-exercises-in-docker-container-for-go-tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ To run all the exercises, run this command in the `go-tests` folder:
 
 ### Run an exercise in the Docker container
 
-To run an exercise as close as it can get to production environment you can call `test_with_docker.sh` as follow:
+First you need to build the image, for example to build it locally you may run:
+
+```
+docker build -t go_tests .
+```
+
+To run an exercise as close as it can get to production environment you can call `test_with_docker.sh` as follows:
 
 ```
 ./test_with_docker.sh [EXERCISE_NAME] [EXERCISE_PATH] [ALLOWED_FUNCTION]*
@@ -35,7 +41,7 @@ As an example:
 ./test_with_docker getalpha getalpha/main.go --allow-builtin github.com/01-edu/z01.PrintRune strconv.Atoi os.Args
 ```
 
-For convenience to do bulk tests you may want to store those info in a `meta.txt` file that will separate them with `:` and then use `awk` to run tests on all of them.
+For convenience to do bulk tests you may want to store this info in a `meta.txt` file that will separate them with `:` and then use `awk` to run tests on all of them.
 
 As an example:
 

--- a/README.md
+++ b/README.md
@@ -20,3 +20,29 @@ To run all the exercises, run this command in the `go-tests` folder:
 ```
 ./test_all.sh
 ```
+
+### Run an exercise in the Docker container
+
+To run an exercise as close as it can get to production environment you can call `test_with_docker.sh` as follow:
+
+```
+./test_with_docker.sh [EXERCISE_NAME] [EXERCISE_PATH] [ALLOWED_FUNCTION]*
+```
+
+As an example:
+
+```console
+./test_with_docker getalpha getalpha/main.go --allow-builtin github.com/01-edu/z01.PrintRune strconv.Atoi os.Args
+```
+
+For convenience to do bulk tests you may want to store those info in a `meta.txt` file that will separate them with `:` and then use `awk` to run tests on all of them.
+
+As an example:
+
+```console
+# The meta.txt file
+getalpha:getalpha/main.go:--allow-builtin github.com/01-edu/z01.PrintRune strconv.Atoi os.Args
+
+# The command to run
+cat meta.txt | awk -F ":" '{print system("./test_with_docker.sh "$1" "$2" "$3)}'
+```

--- a/test_with_docker.sh
+++ b/test_with_docker.sh
@@ -4,6 +4,12 @@ IFS='
 '
 cd -P "$(dirname "$0")"
 
+if [[ "$#" -lt  2 ]]; then
+    echo "Error: run with ./test_with_docker.sh EXERCISE_NAME EXERCISE_FILE ALLOWED_FUNCTIONS"
+    echo "ALLOWED_FUNCTIONS is optional"
+    exit 1
+fi
+
 EXERCISE_NAME=$1
 EXERCISE_FILE=$2
 ALLOWED_FUNCTIONS="$(echo "${@:3}")"

--- a/test_with_docker.sh
+++ b/test_with_docker.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+IFS='
+'
+cd -P "$(dirname "$0")"
+
+EXERCISE_NAME=$1
+EXERCISE_FILE=$2
+ALLOWED_FUNCTIONS="$(echo "${@:3}")"
+
+echo $EXERCISE_NAME $EXERCISE_FILE $ALLOWED_FUNCTIONS
+
+docker run --read-only \
+			--network none \
+			--memory 500M \
+			--cpus 2.0 \
+			--user 1000:1000 \
+            --env FILE="$EXERCISE_FILE" \
+			--env EXERCISE="$EXERCISE_NAME" \
+            --env ALLOWED_FUNCTIONS="$ALLOWED_FUNCTIONS" \
+			--env USERNAME=msessa \
+			--env HOME=/jail \
+			--env TMPDIR=/jail \
+			--workdir /jail \
+			--tmpfs /jail:size=100M,noatime,exec,nodev,nosuid,uid=1000,gid=1000,nr_inodes=5k,mode=1700 \
+			--volume "$(pwd)"/../piscine-go:/jail/student:ro \
+			-t go_tests


### PR DESCRIPTION
Should speed-up the testing process
requires valid solutions in `piscine-go` next to `go-tests`