### PR TITLE
DEV 5204 Replace EXAM_MODE & EXAM_RUN_ONLY for go-tests

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,12 +5,12 @@ set -e
 cp -r student piscine-go
 cd piscine-go
 
-if test "$EXAM_MODE"; then
+if test "$CODE_EDITOR_MODE"; then
 	go mod init main 2>/dev/null
 	GOSUMDB=off go get github.com/01-edu/z01@v0.1.0 2>/dev/null
 fi
 
-if test "$EXAM_RUN_ONLY" = true; then
+if test "$CODE_EDITOR_RUN_ONLY" = true; then
 	if command -v "${EXERCISE}_test" >/dev/null 2>&1; then
 		# The exercise is a program
 		go run "./$EXERCISE" "$@"
@@ -21,7 +21,7 @@ if test "$EXAM_RUN_ONLY" = true; then
 	exit
 fi
 
-if ! test "$EXAM_MODE"; then
+if ! test "$CODE_EDITOR_MODE"; then
 	s=$(gofumpt -d .)
 	if test "$s"; then
 		echo 'Your Go files are not correctly formatted :'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+# support both variables CODE_EDITOR_RUN_ONLY and EXAM_RUN_ONLY
+CODE_EDITOR_RUN_ONLY="${CODE_EDITOR_RUN_ONLY:-$EXAM_RUN_ONLY}"
+# support both variables CODE_EDITOR_MODE and EXAM_MODE
+CODE_EDITOR_MODE="${CODE_EDITOR_MODE:-$EXAM_MODE}"
+
 cp -r student piscine-go
 cd piscine-go
 


### PR DESCRIPTION


If schools enable the code editor for a piscine the students should be able to run their code. For this, we need to handle the variable and the code execution on the test image
